### PR TITLE
Free pa->{host,url} sooner to mitigate crash

### DIFF
--- a/pac.c
+++ b/pac.c
@@ -211,8 +211,6 @@ static void main_result(void *arg)
 
     pa->cb(pa->result, pa->arg);
 
-    free(pa->host);
-    free(pa->url);
     free(pa);
 }
 
@@ -262,6 +260,11 @@ static void _pac_find_proxy(void *arg)
     duk_context *ctx = pop_context(pac);
 
     pa->result = find_proxy(ctx, pa->url, pa->host);
+
+    free(pa->host);
+    pa->host = NULL:
+    free(pa->url);
+    pa->url = NULL;
 
     push_context(pac, ctx);
 

--- a/pac.c
+++ b/pac.c
@@ -210,10 +210,10 @@ static void main_result(void *arg)
     struct proxy_args *pa = arg;
 
     if (pa->host != NULL) {
-        logw("Assertion error: pa->host == NULL");
+        logw("Assertion error: pa->host == %p", pa->host);
     }
     if (pa->url != NULL) {
-        logw("Assertion error: pa->url == NULL");
+        logw("Assertion error: pa->url == %p", pa->url);
     }
 
     pa->cb(pa->result, pa->arg);

--- a/pac.c
+++ b/pac.c
@@ -209,6 +209,13 @@ static void main_result(void *arg)
 {
     struct proxy_args *pa = arg;
 
+    if (pa->host != NULL) {
+        logw("Assertion error: pa->host == NULL");
+    }
+    if (pa->url != NULL) {
+        logw("Assertion error: pa->url == NULL");
+    }
+
     pa->cb(pa->result, pa->arg);
 
     free(pa);
@@ -262,7 +269,7 @@ static void _pac_find_proxy(void *arg)
     pa->result = find_proxy(ctx, pa->url, pa->host);
 
     free(pa->host);
-    pa->host = NULL:
+    pa->host = NULL;
     free(pa->url);
     pa->url = NULL;
 


### PR DESCRIPTION
Crash report was:

    $ i686-w64-mingw32-addr2line -e sc.exe 0x75676e61 0x41be88
    ??:0
    /home/travis/build/saucelabs/libsauceconnect/libpac/pac.c:214

Looking at pac:214 we find that offending line is a `free()` call:

    static void main_result(void *arg)
    {
        struct proxy_args *pa = arg;

        pa->cb(pa->result, pa->arg);

        free(pa->host);
        free(pa->url);
        free(pa);
    }

`pa->host` is an invalid pointer, and `main_result` is a callback that gets
triggered from `pac_find_proxy`. `pa->host` is allocated at pac.c:392:

    int pac_find_proxy(struct pac *pac, char *url, char *host,
                       void (*cb)(char *_result, void *_arg), void *arg)
    {
        struct proxy_args *pa = malloc(sizeof(struct proxy_args));

        [...]
        pa->host = strdup(host);


`pa->host` is then passed to the function `find_proxy` that passes it to the
"Javascript interpreter", and unless `find_proxy` frees up `char *host` this
shouldn't modify `pa->host`:

    static char *find_proxy(duk_context *ctx, char *url, char *host)
    {
        char *result = NULL;
        const char *proxy;

        duk_push_global_object(ctx);
        duk_get_prop_string(ctx, -1 /*index*/, "FindProxyForURL");
        duk_push_string(ctx, url);
        duk_push_string(ctx, host);

        if (duk_pcall(ctx, 2 /*nargs*/) == DUK_EXEC_SUCCESS) {
            proxy = duk_to_string(ctx, -1);
            if (!proxy)
                logw("Failed to allocate proxy string.");
            else
                result = strdup(proxy);
        } else {
            logw("Javascript call failed: %s.", duk_to_string(ctx, -1));
        }

        duk_pop(ctx); /* Result string. */
        duk_pop(ctx); /* Global object. */

        return result;
    }

I was unable to find anything that would trigger `pa->host` to be overwritten,
but I found out that we could free the memory earlier. This may mitigate the
crash: `main_result` doesn't use `pa->url` or `pa->host` but it frees it, the
last function to use those is `find_proxy` so it make sense to move the free()
there.
